### PR TITLE
接続先URLを修正

### DIFF
--- a/src/app/speech_shatter/component.tsx
+++ b/src/app/speech_shatter/component.tsx
@@ -1,4 +1,4 @@
-// src/app/speech_shatter/component.tsx (最終改善版)
+// src/app/speech_shatter/component.tsx (環境変数対応・最終版)
 
 "use client";
 
@@ -14,25 +14,34 @@ const SpeechShatterComponent = () => {
   const streamRef = useRef<MediaStream | null>(null);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const socketRef = useRef<WebSocket | null>(null);
-  // ▼▼▼【変更点1】初回接続試行のフラグをuseRefで管理 ▼▼▼
   const isInitialAttempt = useRef(true);
 
   useEffect(() => {
     setStatusMessage('WebSocketサーバーに接続しています...');
 
-    socketRef.current = new WebSocket("ws://localhost:8000/ws_test/ws/yuka");
+    // 環境変数からベースURLを取得
+    const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+    if (!apiBaseUrl) {
+      setStatusMessage("エラー: APIの接続先URLが設定されていません。");
+      console.error("環境変数 NEXT_PUBLIC_API_BASE_URL が設定されていません。");
+      return;
+    }
+
+    // WebSocketのURLを動的に生成
+    // httpをwsに、httpsをwssに置換することで、ローカルでも本番でも対応
+    const wsUrl = apiBaseUrl.replace(/^http/, 'ws') + "/ws_test/ws/yuka";
+    console.log("接続先のWebSocket URL:", wsUrl); // デバッグ用にURLを確認
+    
+    socketRef.current = new WebSocket(wsUrl);
 
     socketRef.current.onopen = () => {
       console.log("WebSocket接続に成功しました。");
       setStatusMessage('認識待機中（下のボタンで開始）');
-      // ▼▼▼【変更点2】接続が成功したら、初回試行フラグをfalseにする ▼▼▼
       isInitialAttempt.current = false;
     };
 
     socketRef.current.onerror = (error) => {
-      // ▼▼▼【変更点3】初回接続試行中(isInitialAttempt.currentがtrue)はコンソールにエラーを出力しない ▼▼▼
       if (!isInitialAttempt.current) {
-        // 2回目以降の「本物の」エラーだけをコンソールに出力する
         console.error("WebSocket接続エラー:", error);
       }
       setStatusMessage('エラー: WebSocketサーバーに接続できません。');
@@ -40,7 +49,6 @@ const SpeechShatterComponent = () => {
 
     socketRef.current.onclose = () => {
       console.warn("WebSocket接続が終了しました。");
-      // ▼▼▼【変更点4】本物のエラーの場合のみUIに反映させるように条件を少し変更 ▼▼▼
       if (!isInitialAttempt.current && isRecording) {
           setStatusMessage('エラー: WebSocket接続が切れました。');
       }
@@ -52,16 +60,19 @@ const SpeechShatterComponent = () => {
       }
       stopAutoRecording();
     };
-  }, []);
+  }, []); // useEffectの依存配列は空のまま
 
-  // ... (以降の sendBlobToServer, startAutoRecordingなどの関数は変更なし)
   const sendBlobToServer = (blob: Blob) => {
     if (blob.size === 0) return;
     
     const formData = new FormData();
     formData.append('audio_file', blob, 'recording.webm');
 
-    fetch('http://localhost:8000/transcribe_audio', {
+    // fetchのURLも動的に生成
+    const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+    const fetchUrl = `${apiBaseUrl}/transcribe_audio`;
+
+    fetch(fetchUrl, {
       method: 'POST',
       body: formData,
     })
@@ -134,7 +145,6 @@ const SpeechShatterComponent = () => {
   const stopAutoRecording = () => {
     if (!isRecording || !recorder.current) return;
     
-    // 接続が確立している場合のみ待機メッセージに戻す
     if(socketRef.current && socketRef.current.readyState === WebSocket.OPEN) {
       setStatusMessage('認識待機中（下のボタンで開始）');
     }


### PR DESCRIPTION
@yochanchan 

ご指摘いただいた点、修正したので再度プルリクさせていただきます！

- localhost でハードコードされていた部分を、環境変数（NEXT_PUBLIC_API_BASE_URL）から動的にURLを読み込むように変更しました。
- これにより、ローカル環境とデプロイ後の本番環境の両方で、それぞれの正しいバックエンドに接続できるようになったはずです。
- この変更に伴い、ローカルで開発を行うためにはフロントエンドのルートディレクトリに.env.localファイルを作成し、以下の内容を記述する必要があります。
`NEXT_PUBLIC_API_BASE_URL=http://localhost:8000`